### PR TITLE
Implementing arguments passed back to callbacks

### DIFF
--- a/RNPhotoEditor.js
+++ b/RNPhotoEditor.js
@@ -48,8 +48,8 @@ class PhotoEditor extends PureComponent {
       (...args) => {
         props.onDone && props.onDone(...args);
       },
-      () => {
-        props.onCancel && props.onCancel();
+      (...args) => {
+        props.onCancel && props.onCancel(...args);
       }
     );
   }

--- a/RNPhotoEditor.js
+++ b/RNPhotoEditor.js
@@ -45,8 +45,8 @@ class PhotoEditor extends PureComponent {
 
     RNPhotoEditor.Edit(
       props,
-      () => {
-        props.onDone && props.onDone();
+      (...args) => {
+        props.onDone && props.onDone(...args);
       },
       () => {
         props.onCancel && props.onCancel();

--- a/android/src/main/java/com/ahmedadeltito/photoeditor/PhotoEditorActivity.java
+++ b/android/src/main/java/com/ahmedadeltito/photoeditor/PhotoEditorActivity.java
@@ -408,12 +408,13 @@ public class PhotoEditorActivity extends AppCompatActivity implements View.OnCli
                     var7.printStackTrace();
                 }
 
+                Intent returnIntent = new Intent();
+                setResult(Activity.RESULT_OK, returnIntent);
 
                 finish();
             }
         }.start();
     }
-
 
     @Override
     public void onClick(View v) {

--- a/android/src/main/java/ui/photoeditor/RNPhotoEditorModule.java
+++ b/android/src/main/java/ui/photoeditor/RNPhotoEditorModule.java
@@ -1,32 +1,62 @@
 
 package ui.photoeditor;
 
-import android.app.Activity;
-import android.content.res.Resources;
-import android.graphics.Color;
-import android.graphics.drawable.Drawable;
-import android.util.Log;
-import android.graphics.Bitmap;
-import android.graphics.BitmapFactory;
-
+import com.ahmedadeltito.photoeditor.PhotoEditorActivity;
+import com.facebook.react.bridge.ActivityEventListener;
+import com.facebook.react.bridge.BaseActivityEventListener;
+import com.facebook.react.bridge.Callback;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
-import com.facebook.react.bridge.Callback;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
 
-import com.ahmedadeltito.photoeditorsdk.PhotoEditorSDK;
-import com.ahmedadeltito.photoeditor.PhotoEditorActivity;
+import android.util.Log;
+import android.app.Activity;
 import android.content.Intent;
+import android.graphics.Color;
 
 import java.util.ArrayList;
 
 public class RNPhotoEditorModule extends ReactContextBaseJavaModule {
 
+  private static final int PHOTO_EDITOR_REQUEST = 1539266202;
+  private static final String E_PHOTO_EDITOR_CANCELLED = "E_PHOTO_EDITOR_CANCELLED";
+
+
+  private Callback mDoneCallback;
+  private Callback mCancelCallback;
+
+  private final ActivityEventListener mActivityEventListener = new BaseActivityEventListener() {
+
+    @Override
+    public void onActivityResult(Activity activity, int requestCode, int resultCode, Intent intent) {
+      if (requestCode == PHOTO_EDITOR_REQUEST) {
+
+        if (mDoneCallback != null) {
+
+          if (resultCode == Activity.RESULT_CANCELED) {
+            mCancelCallback.invoke(resultCode);
+          } else {
+            mDoneCallback.invoke(intent.getExtras().getString("imagePath"));
+          }
+
+        }
+
+        mCancelCallback = null;
+        mDoneCallback = null;
+      }
+    }
+  };
+
   public RNPhotoEditorModule(ReactApplicationContext reactContext) {
     super(reactContext);
+
+    reactContext.addActivityEventListener(mActivityEventListener);
+
   }
+
+
 
   @Override
   public String getName() {
@@ -70,6 +100,10 @@ public class RNPhotoEditorModule extends ReactContextBaseJavaModule {
     intent.putExtra("hiddenControls", hiddenControlsIntent);
     intent.putExtra("stickers", stickersIntent);
 
-    getCurrentActivity().startActivityForResult(intent, 1);
+
+    mCancelCallback = onCancel;
+    mDoneCallback = onDone;
+
+    getCurrentActivity().startActivityForResult(intent, PHOTO_EDITOR_REQUEST);
   }
 }


### PR DESCRIPTION
This relates to PR https://github.com/prscX/react-native-photo-editor/pull/11 and implements some of the code.  Here is where we implement custom arguments passed back to the CB functions, along with the updated file path for the saved image passed back to the onDone callback. @tonimoeckel thank you very much for implementing the invocation of the CB functions to begin with.