### PR TITLE
Now using standard request code for `PHOTO_EDITOR_REQUEST`

### DIFF
--- a/android/src/main/java/ui/photoeditor/RNPhotoEditorModule.java
+++ b/android/src/main/java/ui/photoeditor/RNPhotoEditorModule.java
@@ -20,7 +20,7 @@ import java.util.ArrayList;
 
 public class RNPhotoEditorModule extends ReactContextBaseJavaModule {
 
-  private static final int PHOTO_EDITOR_REQUEST = 1539266202;
+  private static final int PHOTO_EDITOR_REQUEST = 1;
   private static final String E_PHOTO_EDITOR_CANCELLED = "E_PHOTO_EDITOR_CANCELLED";
 
 


### PR DESCRIPTION
The current request code simply seems to be the timestamp of when it was done, but it needs to be a 16 bit integer. See #21 and https://developer.android.com/training/basics/intents/result

> The integer argument is a "request code" that identifies your request. When you receive the result Intent, the callback provides the same request code so that your app can properly identify the result and determine how to handle it.

It doesn't have to be unique across apps, it's just to validate that the results comes from that request. It could be any other 16 bit number if desired.

Fixes #21