### PR TITLE
Added SWIFT_VERSION to XCode project

### DIFF
--- a/ios/RNPhotoEditor.xcodeproj/project.pbxproj
+++ b/ios/RNPhotoEditor.xcodeproj/project.pbxproj
@@ -313,6 +313,7 @@
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = RNPhotoEditor;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Debug;
 		};
@@ -330,6 +331,7 @@
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = RNPhotoEditor;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Release;
 		};


### PR DESCRIPTION
Without this, the `pod install` fails on CocoaPods 1.6.0 with the following error:

```bash
$ pod install
Analyzing dependencies
Pre-downloading: `iOSPhotoEditor` from `https://github.com/prscX/photo-editor`
Downloading dependencies
Installing iOSPhotoEditor (0.5)
[!] Unable to determine Swift version for the following pods:

- `iOSPhotoEditor` does not specify a Swift version and none of the targets (`RNPhotoEditor`) integrating it have the `SWIFT_VERSION` attribute set. Please contact the author or set the `SWIFT_VERSION` attribute in at least one of the targets that integrate this pod.
```

Even though it do is specified therein. This works around that.