### PR TITLE
Update podspec to support installation from CocoaPods

### DIFF
--- a/ios/RNPhotoEditor.podspec
+++ b/ios/RNPhotoEditor.podspec
@@ -15,11 +15,12 @@ Pod::Spec.new do |s|
   s.library        = 'z'
   s.preserve_paths = '*.js'
   s.source       = { :git => "https://github.com/prscX/react-native-photo-editor.git", :tag => "master" }
-  s.source_files  = "RNPhotoEditor/**/*.{h,m}"
+  s.source_files  = "*.{h,m}"
   s.requires_arc = true
   s.static_framework = true
 
   s.dependency "React"
+  s.dependency "iOSPhotoEditor"
   #s.dependency "others"
 
 end


### PR DESCRIPTION
I have been able to successfully install and build this package from CocoaPods in my project using this podspec. This does imply that I have to install the iOSPhotoEditor depedency myself in my main Podfile, but I feel it is a much cleaner solution to have that stated in the install steps than the current setup.

Closes #47 

I have been able to successfully use this in my Podfile on CocoaPods 1.6.1 and so far it has worked more reliably than the current install method.

```
pod 'RNPhotoEditor', :path => '../node_modules/react-native-photo-editor/ios'
pod 'iOSPhotoEditor', :git => 'https://github.com/prscX/photo-editor'

pre_install do |installer|
installer.analysis_result.specifications.each do |s|
  if s.name.include?('iOSPhotoEditor')
    s.swift_version = '4.1' unless s.swift_version
  end
end
```

**Update**

Additionally, I also got these libraries to work without the need to have `use_frameworks!` in the consumer's Podfile. If this method of installation is desirable by other users of this library I can update this PR with more details.