### PR TITLE
Android EXIF orientation

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -44,4 +44,5 @@ dependencies {
     implementation 'com.android.support:design:27.1.1'
     implementation 'com.android.support:appcompat-v7:27.1.1'
     implementation 'com.android.support.constraint:constraint-layout:1.0.2'
+    implementation 'com.android.support:exifinterface:27.1.1'
 }

--- a/android/src/main/java/com/ahmedadeltito/photoeditor/PhotoEditorActivity.java
+++ b/android/src/main/java/com/ahmedadeltito/photoeditor/PhotoEditorActivity.java
@@ -56,6 +56,7 @@ import java.util.Date;
 import java.util.List;
 
 import ui.photoeditor.R;
+
 public class PhotoEditorActivity extends AppCompatActivity implements View.OnClickListener, OnPhotoEditorSDKListener {
 
     public static Typeface emojiFont = null;
@@ -86,6 +87,7 @@ public class PhotoEditorActivity extends AppCompatActivity implements View.OnCli
         BitmapFactory.Options options = new BitmapFactory.Options();
         options.inSampleSize = 1;
         Bitmap bitmap = BitmapFactory.decodeFile(selectedImagePath, options);
+
         Bitmap rotatedBitmap;
         try {
             ExifInterface exif = new ExifInterface(selectedImagePath);
@@ -94,6 +96,7 @@ public class PhotoEditorActivity extends AppCompatActivity implements View.OnCli
         } catch (IOException e) {
             rotatedBitmap = bitmap;
             imageOrientation = ExifInterface.ORIENTATION_NORMAL;
+
             e.printStackTrace();
         }
 
@@ -412,6 +415,7 @@ public class PhotoEditorActivity extends AppCompatActivity implements View.OnCli
                             FileOutputStream out = new FileOutputStream(file);
                             if (parentImageRelativeLayout != null) {
                                 parentImageRelativeLayout.setDrawingCacheEnabled(true);
+
                                 Bitmap bitmap = parentImageRelativeLayout.getDrawingCache();
                                 Bitmap rotatedBitmap = rotateBitmap(bitmap, imageOrientation, true);
                                 rotatedBitmap.compress(Bitmap.CompressFormat.JPEG, 80, out);
@@ -419,6 +423,7 @@ public class PhotoEditorActivity extends AppCompatActivity implements View.OnCli
 
                             out.flush();
                             out.close();
+
                             try {
                                 ExifInterface exifDest = new ExifInterface(file.getAbsolutePath());
                                 exifDest.setAttribute(ExifInterface.TAG_ORIENTATION, Integer.toString(imageOrientation));
@@ -694,18 +699,22 @@ public class PhotoEditorActivity extends AppCompatActivity implements View.OnCli
 
     private static Bitmap rotateBitmap(Bitmap bitmap, int orientation, boolean reverse) {
         Matrix matrix = new Matrix();
+
         switch (orientation) {
             case ExifInterface.ORIENTATION_NORMAL:
                 return bitmap;
             case ExifInterface.ORIENTATION_FLIP_HORIZONTAL:
                 matrix.setScale(-1, 1);
+
                 break;
             case ExifInterface.ORIENTATION_ROTATE_180:
                 matrix.setRotate(180);
+
                 break;
             case ExifInterface.ORIENTATION_FLIP_VERTICAL:
                 matrix.setRotate(180);
                 matrix.postScale(-1, 1);
+
                 break;
             case ExifInterface.ORIENTATION_TRANSPOSE:
                 if (!reverse) {
@@ -713,6 +722,7 @@ public class PhotoEditorActivity extends AppCompatActivity implements View.OnCli
                 } else {
                     matrix.setRotate(-90);
                 }
+
                 matrix.postScale(-1, 1);
                 break;
             case ExifInterface.ORIENTATION_ROTATE_90:
@@ -721,6 +731,7 @@ public class PhotoEditorActivity extends AppCompatActivity implements View.OnCli
                 } else {
                     matrix.setRotate(-90);
                 }
+
                 break;
             case ExifInterface.ORIENTATION_TRANSVERSE:
                 if (!reverse) {
@@ -728,6 +739,7 @@ public class PhotoEditorActivity extends AppCompatActivity implements View.OnCli
                 } else {
                     matrix.setRotate(90);
                 }
+
                 matrix.postScale(-1, 1);
                 break;
             case ExifInterface.ORIENTATION_ROTATE_270:
@@ -736,10 +748,12 @@ public class PhotoEditorActivity extends AppCompatActivity implements View.OnCli
                 } else {
                     matrix.setRotate(90);
                 }
+
                 break;
             default:
                 return bitmap;
         }
+
         try {
             Bitmap bmRotated = Bitmap.createBitmap(bitmap, 0, 0, bitmap.getWidth(), bitmap.getHeight(), matrix, true);
             bitmap.recycle();

--- a/android/src/main/java/com/ahmedadeltito/photoeditor/PhotoEditorActivity.java
+++ b/android/src/main/java/com/ahmedadeltito/photoeditor/PhotoEditorActivity.java
@@ -419,6 +419,13 @@ public class PhotoEditorActivity extends AppCompatActivity implements View.OnCli
 
                             out.flush();
                             out.close();
+                            try {
+                                ExifInterface exifDest = new ExifInterface(file.getAbsolutePath());
+                                exifDest.setAttribute(ExifInterface.TAG_ORIENTATION, Integer.toString(imageOrientation));
+                                exifDest.saveAttributes();
+                            } catch (IOException e) {
+                                e.printStackTrace();
+                            }
                         } catch (Exception var7) {
                             var7.printStackTrace();
                         }
@@ -465,6 +472,13 @@ public class PhotoEditorActivity extends AppCompatActivity implements View.OnCli
 
                     out.flush();
                     out.close();
+                    try {
+                        ExifInterface exifDest = new ExifInterface(file.getAbsolutePath());
+                        exifDest.setAttribute(ExifInterface.TAG_ORIENTATION, Integer.toString(imageOrientation));
+                        exifDest.saveAttributes();
+                    } catch (IOException e) {
+                        e.printStackTrace();
+                    }
                 } catch (Exception var7) {
                     var7.printStackTrace();
                 }


### PR DESCRIPTION
As soon as I implemented this module I immediately noticed that edited images were not orientated properly on a Samsung Galaxy S8 running Android 9. This is due to the fact that the exif data is not read and the bitmap not rotated accordingly on load/save. This pull request definitely fixes it specifically for my Galaxy S8 but i don't have a wide range of Android devices to fully test this PR on.

Excellent module by the way!