### PR TITLE
Jetifier / AndroidX support

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -14,13 +14,17 @@ buildscript {
 
 apply plugin: 'com.android.library'
 
+def safeExtGet(prop, fallback) {
+    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 android {
-    compileSdkVersion 27
+    compileSdkVersion safeExtGet('compileSdkVersion', 27)
     buildToolsVersion '28.0.2'
 
     defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion 27
+        minSdkVersion safeExtGet('minSdkVersion', 16)
+        targetSdkVersion safeExtGet('targetSdkVersion', 27)
         versionCode 1
         versionName "1.0"
     }
@@ -41,7 +45,17 @@ dependencies {
     implementation 'com.github.prscX:photo-editor-android:master-SNAPSHOT'
     implementation 'fr.avianey.com.viewpagerindicator:library:2.4.1@aar'
     implementation 'com.nineoldandroids:library:2.4.0'
-    implementation 'com.android.support:design:27.1.1'
-    implementation 'com.android.support:appcompat-v7:27.1.1'
-    implementation 'com.android.support.constraint:constraint-layout:1.0.2'
+    
+    def supportLibVersion = safeExtGet('supportLibVersion', '27.0.1')
+    def supportLibMajorVersion = supportLibVersion.split('\\.')[0] as int
+    def designLibVersion = safeExtGet('designLibVersion', safeExtGet('supportLibVersion', '17.0.2'))
+    def constraintLayoutLibVersion = safeExtGet('constraintLayoutLibVersion', '1.0.2')
+    
+    def appCompatLibName =  (supportLibMajorVersion < 20) ? "androidx.appcompat:appcompat" : "com.android.support:appcompat-v7"
+    def appDesignLibName =  (supportLibMajorVersion < 20) ? "androidx.recyclerview:recyclerview" : "com.android.support:design"
+    def appConstraintLayoutLibName =  (supportLibMajorVersion < 20) ? "androidx.constraintlayout:constraintlayout" : "com.android.support:appcompat-v7"
+
+    implementation "$appCompatLibName:$supportLibVersion"
+    implementation "$appDesignLibName:$designLibVersion"
+    implementation "$appConstraintLayoutLibName:$constraintLayoutLibVersion"
 }

--- a/android/src/main/java/com/ahmedadeltito/photoeditor/widget/SlidingUpPanelLayout.java
+++ b/android/src/main/java/com/ahmedadeltito/photoeditor/widget/SlidingUpPanelLayout.java
@@ -1184,7 +1184,7 @@ public class SlidingUpPanelLayout extends ViewGroup {
     @Override
     protected boolean drawChild(Canvas canvas, View child, long drawingTime) {
         boolean result;
-        final int save = canvas.save(Canvas.CLIP_SAVE_FLAG);
+        final int save = canvas.save();
 
         if (mSlideableView != child) { // if main view
             // Clip against the slider; no sense drawing what will immediately be covered,


### PR DESCRIPTION
Hi there, I maintain the jetifier library - https://github.com/mikehardy/jetifier for react-native 0.60 support. This module was involved in an issue with jetifier itself, so I want to include it in my test suite but the library doesn't work with AndroidX or jetifier without some changes: https://github.com/mikehardy/jetifier#module-maintainers

I believe these build.gradle and Canvas API changes are both required for this library to work with react-native 0.60, which uses AndroidX (and by extension, for jetifier to work to migrate the library to AndroidX)

All of these changes are intended to be backwards/forwards-compatible and non-breaking

I'm not 100% certain of the use of the flagless version of Canvas.save so it should be tested for functionality, but it was the recommended API migration path in the current Canvas source code