### PR TITLE
Fix Error in "[CP] Copy Pods Resources"

### DIFF
--- a/Example/ios/Example.xcodeproj/project.pbxproj
+++ b/Example/ios/Example.xcodeproj/project.pbxproj
@@ -279,7 +279,7 @@
 			name = "[CP] Copy Pods Resources";
 			outputPaths = (
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/AccessibilityResources.bundle",
-				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/LaunchScreen.storyboardc",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/LaunchScreen.storyboard",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/ColorCollectionViewCell.nib",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/EmojiCollectionViewCell.nib",
 				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/icomoon.ttf",

--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ pre_install do |installer|
   installer.pod_targets.each do |pod|
     if pod.name.start_with?('RNFB')
       def pod.build_type;
-        Pod::Target::BuildType.static_library
+        Pod::BuildType.static_library
       end
     end
   end
@@ -261,9 +261,10 @@ end
 ```
 
   - If the above doesn't work, try the following and and re-run `pod install`:
+
+As [@react-native-firebase documentation](https://rnfirebase.io/#allow-ios-static-frameworks) you should add following to top of the Podfile for Allow iOS Static Frameworks
 ```
-1. Open .podspec in node_modules/@react-native-firebase/app, auth, firestore (and any other @react-native-firebase libraries you're using)
-2. Manually change s.static_framework = false to s.static_framework = true.
+$RNFirebaseAsStaticFramework = true
 ```
 
 ## ✨ Credits

--- a/ios/RNPhotoEditor.m
+++ b/ios/RNPhotoEditor.m
@@ -16,7 +16,7 @@ RCTResponseSenderBlock _onCancelEditing = nil;
 
 - (void)doneEditingWithImage:(UIImage *)image {
     if (_onDoneEditing == nil) return;
-    
+
     NSError* error;
 
     BOOL isPNG = [_editImagePath.pathExtension.lowercaseString isEqualToString:@"png"];
@@ -30,9 +30,9 @@ RCTResponseSenderBlock _onCancelEditing = nil;
     [isPNG ? UIImagePNGRepresentation(image) : UIImageJPEGRepresentation(image, 0.8) writeToFile:path options:NSDataWritingAtomic error:&error];
 
     if (error != nil)
-        NSLog(@"write error %@", error); 
-   
-    _onDoneEditing(@[]);
+        NSLog(@"write error %@", error);
+
+    _onDoneEditing(@[path]);
 }
 
 - (void)canceledEditing {
@@ -94,7 +94,7 @@ RCT_EXPORT_METHOD(Edit:(nonnull NSDictionary *)props onDone:(RCTResponseSenderBl
 
         // Invoke Editor
         photoEditor.photoEditorDelegate = self;
-	
+
 	// The default modal presenting is page sheet in ios 13, not full screen
 	if (@available(iOS 13, *)) {
             [photoEditor setModalPresentationStyle: UIModalPresentationFullScreen];


### PR DESCRIPTION
Fix following issue:
https://github.com/prscX/react-native-photo-editor/issues/149

Pass path to onDone event(I'm very astonished at how this library was used for IOS)

Update README:
Remove ```Target::``` for cocoapods >= 1.9.0